### PR TITLE
Update allocated-pids.txt

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -584,3 +584,6 @@ PID    | Product name
 0x8240 | kohacraft.com Padauk Programmer - Arduino
 0x8241 | EASYBCI Bio Amp 1
 0x8242 | Waveshare ESP32-S3-Touch-AMOLED-2.41 - Arduino
+0x8243 | Barduino 4 - Arduino
+0x8244 | Barduino 4 - CircuitPython/MicroPython
+0x8245 | Barduino 4 - UF2 Bootloader


### PR DESCRIPTION
Adding Barduino PID's.

Barduino is a development board created by Fablab Barcelona as a tool for it's educational programs. 

ESP32-S3 (ESP32-S3-WROOM-1)

It needs a custom PID to have the opportunity to show it officialy in the CircuitPython website and to create an Arduino core for it. 

It's done under Fablab Barcelona, part of IAAC. 

This is (will be because it's a WIP) the documentation for the board https://fablabbcn-projects.gitlab.io/electronics/barduino-docs/ and this is Fablab Barcelona https://fablabbcn.org/ and this IAAC https://iaac.net/

Thank you!